### PR TITLE
Added CoreRepairMultiplier and bShowBuilds Configurable INI Settings

### DIFF
--- a/Classes/CoreDamage.uc
+++ b/Classes/CoreDamage.uc
@@ -1,7 +1,7 @@
 //=============================================================================
 // CoreDamage.
 //=============================================================================
-class CoreDamage expands Mutator config(SiegeIV_0031);
+class CoreDamage expands Mutator config(SiegeIV_0031b);
 
 var config float DamageMultiplyer;
 var config float PlayerDamageMultiplyer;

--- a/Classes/CoreDamage.uc
+++ b/Classes/CoreDamage.uc
@@ -1,7 +1,7 @@
 //=============================================================================
 // CoreDamage.
 //=============================================================================
-class CoreDamage expands Mutator config(SiegeIV_0031);
+class CoreDamage expands Mutator config(SiegeIV_0031rep);
 
 var config float DamageMultiplyer;
 var config float PlayerDamageMultiplyer;

--- a/Classes/CoreDamage.uc
+++ b/Classes/CoreDamage.uc
@@ -1,7 +1,7 @@
 //=============================================================================
 // CoreDamage.
 //=============================================================================
-class CoreDamage expands Mutator config(SiegeIV_0031rep);
+class CoreDamage expands Mutator config(SiegeIV_0031);
 
 var config float DamageMultiplyer;
 var config float PlayerDamageMultiplyer;

--- a/Classes/Import.uc
+++ b/Classes/Import.uc
@@ -8,13 +8,13 @@ var string nullprotected_;
 var int bogus1, bogus2, bogus3, bogus4, bogus5;
 
 //Kept for historic reference
-//#exec OBJ LOAD FILE="Graphics\JetpackTex.utx" PACKAGE=SiegeIV_0031.Jetpack
+//#exec OBJ LOAD FILE="Graphics\JetpackTex.utx" PACKAGE=SiegeIV_0031b.Jetpack
 
-#exec OBJ LOAD FILE="Graphics\XC_Orb.utx" PACKAGE=SiegeIV_0031
-#exec OBJ LOAD FILE="Graphics\BuildingGraphics.utx" PACKAGE=SiegeIV_0031.BuildingGraphics
+#exec OBJ LOAD FILE="Graphics\XC_Orb.utx" PACKAGE=SiegeIV_0031b
+#exec OBJ LOAD FILE="Graphics\BuildingGraphics.utx" PACKAGE=SiegeIV_0031b.BuildingGraphics
 #exec TEXTURE IMPORT NAME=Shade FILE=Graphics\Shade.PCX GROUP=ScoreBoard
 #exec TEXTURE IMPORT NAME=Shade2 FILE=Graphics\Shade2.PCX GROUP=ScoreBoard
-#exec OBJ LOAD FILE="SiegeUtil_A.u" PACKAGE=SiegeIV_0031
+#exec OBJ LOAD FILE="SiegeUtil_A.u" PACKAGE=SiegeIV_0031b
 
 // Stuff that helps making Siege smaller
 #exec OBJ LOAD File=sgMedia.u

--- a/Classes/Import.uc
+++ b/Classes/Import.uc
@@ -8,13 +8,13 @@ var string nullprotected_;
 var int bogus1, bogus2, bogus3, bogus4, bogus5;
 
 //Kept for historic reference
-//#exec OBJ LOAD FILE="Graphics\JetpackTex.utx" PACKAGE=SiegeIV_0031.Jetpack
+//#exec OBJ LOAD FILE="Graphics\JetpackTex.utx" PACKAGE=SiegeIV_0031rep.Jetpack
 
-#exec OBJ LOAD FILE="Graphics\XC_Orb.utx" PACKAGE=SiegeIV_0031
-#exec OBJ LOAD FILE="Graphics\BuildingGraphics.utx" PACKAGE=SiegeIV_0031.BuildingGraphics
+#exec OBJ LOAD FILE="Graphics\XC_Orb.utx" PACKAGE=SiegeIV_0031rep
+#exec OBJ LOAD FILE="Graphics\BuildingGraphics.utx" PACKAGE=SiegeIV_0031rep.BuildingGraphics
 #exec TEXTURE IMPORT NAME=Shade FILE=Graphics\Shade.PCX GROUP=ScoreBoard
 #exec TEXTURE IMPORT NAME=Shade2 FILE=Graphics\Shade2.PCX GROUP=ScoreBoard
-#exec OBJ LOAD FILE="SiegeUtil_A.u" PACKAGE=SiegeIV_0031
+#exec OBJ LOAD FILE="SiegeUtil_A.u" PACKAGE=SiegeIV_0031rep
 
 // Stuff that helps making Siege smaller
 #exec OBJ LOAD File=sgMedia.u

--- a/Classes/Import.uc
+++ b/Classes/Import.uc
@@ -8,13 +8,13 @@ var string nullprotected_;
 var int bogus1, bogus2, bogus3, bogus4, bogus5;
 
 //Kept for historic reference
-//#exec OBJ LOAD FILE="Graphics\JetpackTex.utx" PACKAGE=SiegeIV_0031rep.Jetpack
+//#exec OBJ LOAD FILE="Graphics\JetpackTex.utx" PACKAGE=SiegeIV_0031.Jetpack
 
-#exec OBJ LOAD FILE="Graphics\XC_Orb.utx" PACKAGE=SiegeIV_0031rep
-#exec OBJ LOAD FILE="Graphics\BuildingGraphics.utx" PACKAGE=SiegeIV_0031rep.BuildingGraphics
+#exec OBJ LOAD FILE="Graphics\XC_Orb.utx" PACKAGE=SiegeIV_0031
+#exec OBJ LOAD FILE="Graphics\BuildingGraphics.utx" PACKAGE=SiegeIV_0031.BuildingGraphics
 #exec TEXTURE IMPORT NAME=Shade FILE=Graphics\Shade.PCX GROUP=ScoreBoard
 #exec TEXTURE IMPORT NAME=Shade2 FILE=Graphics\Shade2.PCX GROUP=ScoreBoard
-#exec OBJ LOAD FILE="SiegeUtil_A.u" PACKAGE=SiegeIV_0031rep
+#exec OBJ LOAD FILE="SiegeUtil_A.u" PACKAGE=SiegeIV_0031
 
 // Stuff that helps making Siege smaller
 #exec OBJ LOAD File=sgMedia.u

--- a/Classes/SiegeGI.uc
+++ b/Classes/SiegeGI.uc
@@ -3,7 +3,7 @@
 // * Extended by WILDCARD
 // * Optimized and improved by Higor
 //=============================================================================
-class SiegeGI extends TeamGamePlus config(SiegeIV_0031rep);
+class SiegeGI extends TeamGamePlus config(SiegeIV_0031);
 
 var class<Object> GCBind; //SiegeNative plugin ref to prevent GC cleaning
 

--- a/Classes/SiegeGI.uc
+++ b/Classes/SiegeGI.uc
@@ -3,6 +3,7 @@
 // * Extended by WILDCARD
 // * Optimized and improved by Higor
 // * Added CoreRepairMultiplier config var by nut_zac
+// * Added bool value to show builds by nut_zac
 //=============================================================================
 class SiegeGI extends TeamGamePlus config(SiegeIV_0031);
 
@@ -28,6 +29,7 @@ var() config bool bBotCanCheat;
 var() config bool bCore5AddsEnforcer;
 var() config bool bPlayersRelevant;
 var() config float CoreRepairMultiplier;
+var() config bool bShowBuilds;
 
 // The Map Specific List
 var config vector RandomSpawnerLocation[32];

--- a/Classes/SiegeGI.uc
+++ b/Classes/SiegeGI.uc
@@ -26,6 +26,7 @@ var() config bool bDisableIDropFix;
 var() config bool bBotCanCheat;
 var() config bool bCore5AddsEnforcer;
 var() config bool bPlayersRelevant;
+var() config float CoreRepairMultiplier;
 
 // The Map Specific List
 var config vector RandomSpawnerLocation[32];
@@ -2384,6 +2385,7 @@ defaultproperties
      RoundRuScale=2
      bUseNukeDeco=False
      bCore5AddsEnforcer=True
+	 CoreRepairMultiplier=4.0
      BaseMotion=70
      TranslocBaseForce=800
      TranslocLevelForce=120

--- a/Classes/SiegeGI.uc
+++ b/Classes/SiegeGI.uc
@@ -2,6 +2,7 @@
 // * Revised by nOs*Badger
 // * Extended by WILDCARD
 // * Optimized and improved by Higor
+// * Added CoreRepairMultiplier config var by nut_zac
 //=============================================================================
 class SiegeGI extends TeamGamePlus config(SiegeIV_0031);
 

--- a/Classes/SiegeGI.uc
+++ b/Classes/SiegeGI.uc
@@ -2389,6 +2389,7 @@ defaultproperties
      bUseNukeDeco=False
      bCore5AddsEnforcer=True
 	 CoreRepairMultiplier=4.0
+	 bShowBulds=True
      BaseMotion=70
      TranslocBaseForce=800
      TranslocLevelForce=120

--- a/Classes/SiegeGI.uc
+++ b/Classes/SiegeGI.uc
@@ -3,7 +3,7 @@
 // * Extended by WILDCARD
 // * Optimized and improved by Higor
 //=============================================================================
-class SiegeGI extends TeamGamePlus config(SiegeIV_0031);
+class SiegeGI extends TeamGamePlus config(SiegeIV_0031rep);
 
 var class<Object> GCBind; //SiegeNative plugin ref to prevent GC cleaning
 

--- a/Classes/SiegeGI.uc
+++ b/Classes/SiegeGI.uc
@@ -5,7 +5,7 @@
 // * Added CoreRepairMultiplier config var by nut_zac
 // * Added bool value to show builds by nut_zac
 //=============================================================================
-class SiegeGI extends TeamGamePlus config(SiegeIV_0031);
+class SiegeGI extends TeamGamePlus config(SiegeIV_0031b);
 
 var class<Object> GCBind; //SiegeNative plugin ref to prevent GC cleaning
 

--- a/Classes/sgConstructor.uc
+++ b/Classes/sgConstructor.uc
@@ -1115,6 +1115,9 @@ function bool RepairFunction( float DeltaRep)
 		// check if core. Set core repair multiplier amount to repair amount.
 		if(sgBaseCore(HitActor) != none
 		&& SiegeGI(Level.Game) != none){
+			if(SiegeGI(Level.Game).CoreRepairMultiplier < 1)
+				return;
+
 			fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, (60/ SiegeGI(Level.Game).CoreRepairMultiplier) * DeltaRep);
 		} else {
 			fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 60 * DeltaRep);

--- a/Classes/sgConstructor.uc
+++ b/Classes/sgConstructor.uc
@@ -1115,7 +1115,7 @@ function bool RepairFunction( float DeltaRep)
 		// check if core. Set core repair multiplier amount to repair amount.
 		if(sgBaseCore(HitActor) != none
 		&& SiegeGI(Level.Game) != none){
-			DeltaRep = DeltaRep / SiegeGI.CoreRepairMultiplier;
+			DeltaRep = DeltaRep / SiegeGI(Level.Game).CoreRepairMultiplier;
 		}
 
 		fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 60 * DeltaRep);

--- a/Classes/sgConstructor.uc
+++ b/Classes/sgConstructor.uc
@@ -8,7 +8,7 @@
 class sgConstructor extends TournamentWeapon;
 
 
-#exec OBJ LOAD FILE="Graphics\ConstructorTex.utx" PACKAGE=SiegeIV_0031.Constructor
+#exec OBJ LOAD FILE="Graphics\ConstructorTex.utx" PACKAGE=SiegeIV_0031rep.Constructor
 
 //Pick up view mesh contributed by DeepakOV
 #exec mesh import mesh=ConstructorPick anivfile=Models\ConstructorPick_a.3d datafile=Models\ConstructorPick_d.3d x=0 y=0 z=0 mlod=0

--- a/Classes/sgConstructor.uc
+++ b/Classes/sgConstructor.uc
@@ -2,6 +2,7 @@
 // sg_XC_Constructor.
 //
 // Experimental constructor, model and class made by Higor
+// Reduced amount of repair to core by zaccyboy
 //
 //=============================================================================
 class sgConstructor extends TournamentWeapon;

--- a/Classes/sgConstructor.uc
+++ b/Classes/sgConstructor.uc
@@ -1112,12 +1112,13 @@ function bool RepairFunction( float DeltaRep)
 	if ( sgBest != none )
 	{
 		
-		if(sgBaseCore(HitActor) != none){
-			// if base core, reduce delta rep to 1/4 normal amount.
-			fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 15 * DeltaRep);
-		}else{
-			fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 60 * DeltaRep);
+		// check if core. Set core repair multiplier amount to repair amount.
+		if(sgBaseCore(HitActor) != none
+		&& SiegeGI(Level.Game) != none){
+			DeltaRep = DeltaRep / SiegeGI.CoreRepairMultiplier;
 		}
+
+		fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 60 * DeltaRep);
 
 		if ( SiegeGI(Level.Game) == None || !SiegeGI(Level.Game).FreeBuild )
 		{

--- a/Classes/sgConstructor.uc
+++ b/Classes/sgConstructor.uc
@@ -8,7 +8,7 @@
 class sgConstructor extends TournamentWeapon;
 
 
-#exec OBJ LOAD FILE="Graphics\ConstructorTex.utx" PACKAGE=SiegeIV_0031rep.Constructor
+#exec OBJ LOAD FILE="Graphics\ConstructorTex.utx" PACKAGE=SiegeIV_0031.Constructor
 
 //Pick up view mesh contributed by DeepakOV
 #exec mesh import mesh=ConstructorPick anivfile=Models\ConstructorPick_a.3d datafile=Models\ConstructorPick_d.3d x=0 y=0 z=0 mlod=0
@@ -1115,10 +1115,12 @@ function bool RepairFunction( float DeltaRep)
 		// check if core. Set core repair multiplier amount to repair amount.
 		if(sgBaseCore(HitActor) != none
 		&& SiegeGI(Level.Game) != none){
-			DeltaRep = DeltaRep / SiegeGI(Level.Game).CoreRepairMultiplier;
+			fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, (60/ SiegeGI(Level.Game).CoreRepairMultiplier) * DeltaRep);
+		} else {
+			fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 60 * DeltaRep);
 		}
 
-		fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 60 * DeltaRep);
+
 
 		if ( SiegeGI(Level.Game) == None || !SiegeGI(Level.Game).FreeBuild )
 		{

--- a/Classes/sgConstructor.uc
+++ b/Classes/sgConstructor.uc
@@ -1110,7 +1110,13 @@ function bool RepairFunction( float DeltaRep)
 
 	if ( sgBest != none )
 	{
-		fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 60 * DeltaRep);
+		
+		if(sgBaseCore(HitActor) != none){
+			// if base core, reduce delta rep to 1/4 normal amount.
+			fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 15 * DeltaRep);
+		}else{
+			fPri = FMin(sgBest.MaxEnergy - sgBest.Energy, 60 * DeltaRep);
+		}
 
 		if ( SiegeGI(Level.Game) == None || !SiegeGI(Level.Game).FreeBuild )
 		{

--- a/Classes/sgConstructor.uc
+++ b/Classes/sgConstructor.uc
@@ -8,7 +8,7 @@
 class sgConstructor extends TournamentWeapon;
 
 
-#exec OBJ LOAD FILE="Graphics\ConstructorTex.utx" PACKAGE=SiegeIV_0031.Constructor
+#exec OBJ LOAD FILE="Graphics\ConstructorTex.utx" PACKAGE=SiegeIV_0031b.Constructor
 
 //Pick up view mesh contributed by DeepakOV
 #exec mesh import mesh=ConstructorPick anivfile=Models\ConstructorPick_a.3d datafile=Models\ConstructorPick_d.3d x=0 y=0 z=0 mlod=0

--- a/Classes/sgScore.uc
+++ b/Classes/sgScore.uc
@@ -261,10 +261,19 @@ function ShowScores(Canvas Canvas)
 			Canvas.SetPos(X+xLen+paddingInfo+40, Y + yLen + 9);
 			Canvas.DrawText("Dths:"@int(aPRI.Deaths), false); //@sgPRI(PRI).sgInfoKiller
 			
-	  		  // Draw Buildings
-	  		Canvas.DrawColor=getTeamColor[2];
-			Canvas.SetPos(X+paddingInfo+40, Y + 2 * yLen + 11);
-			Canvas.DrawText("Build:"@aPRI.sgInfoBuildingMaker, false);
+
+			// Draw Buildings
+			if(SiegeGI(Level.Game).bShowBuilds){
+				Canvas.DrawColor=getTeamColor[2];
+				Canvas.SetPos(X+paddingInfo+40, Y + 2 * yLen + 11);
+				Canvas.DrawText("Build:"@aPRI.sgInfoBuildingMaker, false);
+			}
+			else if(aPRI.Team == Pawn(Owner).PlayerReplicationInfo.Team)
+			{
+				Canvas.DrawColor=getTeamColor[2];
+				Canvas.SetPos(X+paddingInfo+40, Y + 2 * yLen + 11);
+				Canvas.DrawText("Build:"@aPRI.sgInfoBuildingMaker, false);
+			}
 		  
 			// Draw Effective
 			Canvas.DrawColor=Orange;

--- a/Classes/sgScore.uc
+++ b/Classes/sgScore.uc
@@ -268,7 +268,7 @@ function ShowScores(Canvas Canvas)
 				Canvas.SetPos(X+paddingInfo+40, Y + 2 * yLen + 11);
 				Canvas.DrawText("Build:"@aPRI.sgInfoBuildingMaker, false);
 			}
-			else if(aPRI.Team == Pawn(Owner).PlayerReplicationInfo.Team)
+			else if(aPRI.Team == Pawn(Owner).PlayerReplicationInfo.Team || aPRI.bIsSpectator)
 			{
 				Canvas.DrawColor=getTeamColor[2];
 				Canvas.SetPos(X+paddingInfo+40, Y + 2 * yLen + 11);


### PR DESCRIPTION
This pull request adds the configuration of changing the core repair amount multiplier and a bool value to toggle if to show build numbers to the opposing team.
```
// SiegeIV_0031.ini

// Will make repair to core 4x slower. Setting to 2 will be twice as slow as normal. 1 is normal.
CoreRepairMultipler=4.000000

// Setting to false will hide builds from the opposing team. (default is false) 
// Setting to true will show build counts to all players.
bShowBuilds=false
```